### PR TITLE
Cache compatibility fix

### DIFF
--- a/djdev_panel/middleware.py
+++ b/djdev_panel/middleware.py
@@ -172,6 +172,9 @@ class DebugMiddleware:
 
     def process_template_response(self, request, response):
 
+        if not hasattr(response, 'context_data'):
+            return response
+
         if response.context_data is None:
             return response
 


### PR DESCRIPTION
Check to make sure response has a context_data attribute before trying to access it.
This should improve compatibility with various other middleware, such as caches, that may not always pass a response on with a context_data attribute. There should be no bad side-effects.

Originally reported over on the Wagtail-Cache repo here: https://github.com/coderedcorp/wagtail-cache/issues/5

This PR makes the two packages work nicely together.